### PR TITLE
don't break the clickable links in emails

### DIFF
--- a/doctors/views.py
+++ b/doctors/views.py
@@ -180,7 +180,7 @@ class AbstractDeclareView():
                 work_detail.declaration = detailed_declaration
                 work_detail.save()
 
-        self.link.delete()
+        #self.link.delete()
         if not settings.SKIP_EMAIL_VERIFICATION:
             self.object.send_declaration_thanks()
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
People often try to reclick links they've used before they expire (which is usually next day anyway), especially now we have per-year submissions and people backfill missing years. It matters less for email addresses which can easily recreate links (nhs.net etc), but matters a lot for those who (now) have to re-request a custom link (@gmail.com etc). Not sure this is the right/only place, so needs review from someone who wrote this code. Not urgent